### PR TITLE
Fixes #5: Port GObject based method to GLib

### DIFF
--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -1,6 +1,6 @@
 import logging
 from gi.repository import Gdk
-from gi.repository import GObject
+from gi.repository import GLib
 import pygame
 import pygame.event
 
@@ -237,9 +237,9 @@ class Translator(object):
 
     def _set_repeat(self, delay=None, interval=None):
         if delay is not None and self.__repeat[0] is None:
-            self.__tick_id = GObject.timeout_add(10, self._tick_cb)
+            self.__tick_id = GLib.timeout_add(10, self._tick_cb)
         elif delay is None and self.__repeat[0] is not None:
-            GObject.source_remove(self.__tick_id)
+            GLib.source_remove(self.__tick_id)
         self.__repeat = (delay, interval)
 
     def _get_mouse_pos(self):


### PR DESCRIPTION
### Explanation
This PR ports GObject based methods to GLib. 

### Reason
Thousands of PyGIDeprecationWarning occur in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### Test result
No error related to the port from GObject to GLib.
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/followme$ sugar-activity

(sugar-activity:3164): Gtk-WARNING **: 11:44:07.732: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:3164): Gtk-WARNING **: 11:44:07.732: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version

```