### PR TITLE
Remove recursion on Activity resize

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -113,6 +113,7 @@ class PeterActivity(activity.Activity):
                                  Gdk.Screen.height() - GRID_CELL_SIZE),
                                 pygame.RESIZABLE)
         self.game.save_pattern()
+        self.game.g_init()
         self._speed_range.set_value(800)
 
     def read_file(self, file_path):

--- a/activity.py
+++ b/activity.py
@@ -113,9 +113,7 @@ class PeterActivity(activity.Activity):
                                  Gdk.Screen.height() - GRID_CELL_SIZE),
                                 pygame.RESIZABLE)
         self.game.save_pattern()
-        self.game.g_init()
         self._speed_range.set_value(800)
-        self.game.run(restore=True)
 
     def read_file(self, file_path):
         try:


### PR DESCRIPTION
Fixes #7 

Test method

1) Run activity with sugar-activity
2) Open Ubuntu Displays setting
3) Change orientation from landscape to any of the other options
4) Use the activity (No traceback is observed)
5) Rotate display back to landscape
6) Use activity (No traceback is observed)
7) Stop activity

The activity terminates normally with no process left running. No traceback is observed.

Tested on Sugar v0.114 and Ubuntu 18.04