### PR TITLE
Ensure correct gtk version loaded.

### DIFF
--- a/FollowMe.py
+++ b/FollowMe.py
@@ -17,6 +17,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk
 import sys
 import pygame


### PR DESCRIPTION
When directly running FollowMe.py, ensure that gtk version 3 is loaded to avoid warnings in log.

```
FollowMe.py:20: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded
```